### PR TITLE
add group-target variant

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,5 +5,11 @@ module.exports = plugin(({ addVariant, e }) => {
 			return `.${e(`target${separator}${className}`)}:target`;
 		});
 	});
+	
+	addVariant("group-target", ({ modifySelectors, separator }) => {
+		modifySelectors(({ className }) => {
+			return `.group:target .${e(`group-target${separator}${className}`)}`;
+		});
+	});
 });
 


### PR DESCRIPTION
add a sibling variant "group-target" that reflects the hover and focus group variants ("group-hover:*" and "group-focus:*") for the :target pseudo class ("group-target:*")

This would bring :target inline with the other main pseudo selectors that already have "group-*" variants in tailwind core